### PR TITLE
Added submissions/TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,20 @@ Runs Postfix (as a relay) in Docker
   - `X.X.X`: [Semantic version](https://semver.org/) (use if you want to stick on a specific version)
 
 ### Environment variables
-| Variable    | Required?                 | Definition                                  | Example                    | Comments                                                     |
-|-------------|---------------------------|---------------------------------------------|----------------------------|--------------------------------------------------------------|
-| TZ          | Yes                       | Timezone                                    | America/New_York           | https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
-| RELAY_HOST  | Yes                       | Public SMTP server to use                   | smtp.gmail.com             |                                                              |
-| RELAY_PORT  | Yes                       | Public SMTP port to use                     | 587                        |                                                              |
-| RELAY_USER  | No                        | Address to login to $RELAY_HOST             | SMTP username              |                                                              |
-| RELAY_PASS  | No                        | Password to login to $RELAY_HOST            | SMTP password              | If using Gmail 2FA, you will need to setup an app password   |
-| TEST_EMAIL  | No                        | Address to receive test email               | receive_address@domain.com | If not set, test email will **not** be sent                  |
-| MYORIGIN    | No                        | Domain of the "from" address                | domain.com                 | Needed for things like AWS SES where the domain must be set  |
-| FROMADDRESS | No                        | Changes the "from" address                  | my_email@domain.com        | Needed for some SMTP services where the FROM address needs to be set, [fixes issue 19](https://github.com/loganmarchione/docker-postfixrelay/issues/19) |
-| MYNETWORKS  | No (default: 0.0.0.0/0)   | Networks that Postfix will forward mail for | 1.2.3.4/24, 5.6.7.8/24     | Single or multiple trusted networks separated with a comma   |
-| MSG_SIZE    | No (default: 10240000)    | Postfix `message_size_limit` in bytes       | 30720000                   |                                                              |
-| LOG_DISABLE | No (default: false)       | Setting to `true` disables logging          | true                       |                                                              |
+| Variable           | Required?                 | Definition                                  | Example                    | Comments                                                     |
+|--------------------|---------------------------|---------------------------------------------|----------------------------|--------------------------------------------------------------|
+| TZ                 | Yes                       | Timezone                                    | America/New_York           | https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
+| RELAY_HOST         | Yes                       | Public SMTP server to use                   | smtp.gmail.com             |                                                              |
+| RELAY_PORT         | Yes                       | Public SMTP port to use                     | 587                        |                                                              |
+| RELAY_USER         | No                        | Address to login to $RELAY_HOST             | SMTP username              |                                                              |
+| RELAY_PASS         | No                        | Password to login to $RELAY_HOST            | SMTP password              | If using Gmail 2FA, you will need to setup an app password   |
+| RELAY_SUBMISSIONS  | No (default: false)       | Use of submissions/TLS to $RELAY_HOST       | true                       | Needed when the server requests submissions/implicit TLS (enables Postfix's `tls_wrappermode` [(doc)](https://www.postfix.org/postconf.5.html#smtp_tls_wrappermode)). |
+| TEST_EMAIL         | No                        | Address to receive test email               | receive_address@domain.com | If not set, test email will **not** be sent                  |
+| MYORIGIN           | No                        | Domain of the "from" address                | domain.com                 | Needed for things like AWS SES where the domain must be set  |
+| FROMADDRESS        | No                        | Changes the "from" address                  | my_email@domain.com        | Needed for some SMTP services where the FROM address needs to be set, [fixes issue 19](https://github.com/loganmarchione/docker-postfixrelay/issues/19) |
+| MYNETWORKS         | No (default: 0.0.0.0/0)   | Networks that Postfix will forward mail for | 1.2.3.4/24, 5.6.7.8/24     | Single or multiple trusted networks separated with a comma   |
+| MSG_SIZE           | No (default: 10240000)    | Postfix `message_size_limit` in bytes       | 30720000                   |                                                              |
+| LOG_DISABLE        | No (default: false)       | Setting to `true` disables logging          | true                       |                                                              |
 
 ### Ports
 | Port on host              | Port in container | Comments            |

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,6 +12,7 @@ services:
       - RELAY_PORT=587
       - RELAY_USER=your_email_here@gmail.com
       - RELAY_PASS=your_password_here
+      - RELAY_SUBMISSIONS=true
       - TEST_EMAIL=test_email@domain.com
       - MYORIGIN=domain.com
       - FROMADDRESS=my_email@domain.com

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,6 +98,11 @@ else
   echo -e "Subject: Postfix relay test \r\nTest of Postfix relay from Docker container startup\nSent on $(date)\n" | sendmail -F "[Alert from Postfix]" "$TEST_EMAIL"
 fi
 
+# Enable SUBMISSIONS/TLS
+if [[ "$RELAY_SUBMISSIONS" == "true" ]]; then
+  postconf -e "smtp_tls_wrappermode = yes"
+fi
+
 # Start Postfix
 # Nothing else can log after this
 printf "# STATE: Starting Postfix\n"


### PR DESCRIPTION
Add submissions/TLS (aka SMTPS, ambiguous naming) flag. Needed for hosts that require implicit TLS.

Under the hood it enables Postfix's flag `smtp_tls_wrappermode`.